### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -57,7 +57,8 @@ func (r *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 			role.DisplayName,
 			r.resourceType,
 			role.ID,
-			[]resource.RoleTraitOption{resource.WithRoleProfile(profile)},
+			[]resource.RoleTraitOption{},
+			resource.WithResourceProfile(profile),
 		)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("failed to create role resource: %w", err)

--- a/pkg/connector/teams.go
+++ b/pkg/connector/teams.go
@@ -49,10 +49,8 @@ func teamResource(team *miro.Team) (*v2.Resource, error) {
 		"id":   team.Id,
 	}
 
-	teamTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
-	resource, err := rs.NewGroupResource(team.Name, teamResourceType, team.Id, teamTraitOptions)
+	teamTraitOptions := []rs.GroupTraitOption{}
+	resource, err := rs.NewGroupResource(team.Name, teamResourceType, team.Id, teamTraitOptions, rs.WithResourceProfile(profile))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -54,16 +54,21 @@ func userResource(user *miro.User) (*v2.Resource, error) {
 	}
 
 	userTraits := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
 		rs.WithUserLogin(user.Email),
 		rs.WithEmail(user.Email, true),
-		rs.WithStatus(status),
 	}
 	if lastLogin != nil {
 		userTraits = append(userTraits, rs.WithLastLogin(*lastLogin))
 	}
 
-	resource, err := rs.NewUserResource(user.Email, userResourceType, user.Id, userTraits)
+	resource, err := rs.NewUserResource(
+		user.Email,
+		userResourceType,
+		user.Id,
+		userTraits,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(status), ""),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
